### PR TITLE
Publish bottles automatically on CI success

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,13 +1,45 @@
 name: brew pr-pull
 
 on:
+  # Automatic path: when the test-bot finishes building bottles for an autobump
+  # PR (branch `bump-*`), pull those bottles, push them to ghcr, commit the
+  # updated `bottle do` block, and merge. No label or manual step required.
+  #
+  # This uses `workflow_run` (not the `labeled` event) on purpose: a label added
+  # by the default GITHUB_TOKEN does not trigger a `labeled` workflow, so an
+  # auto-label approach would need a PAT, which expires and reintroduces silent
+  # breakage. `workflow_run` needs no extra credential.
+  workflow_run:
+    workflows: ["brew test-bot"]
+    types:
+      - completed
+
+  # Manual fallback: publish bottles for a specific PR number. Useful to recover
+  # a bump whose bottles were built but never pulled (e.g. a PR that was merged
+  # with the button instead of going through this workflow).
+  workflow_dispatch:
+    inputs:
+      pull_request:
+        description: PR number to pull bottles from
+        required: true
+
+  # Legacy/manual escape hatch: still honour a `pr-pull` label on a PR.
   pull_request_target:
     types:
       - labeled
 
 jobs:
   pr-pull:
-    if: contains(github.event.pull_request.labels.*.name, 'pr-pull')
+    # Run for: a successful test-bot run on an autobump PR; a manual dispatch; or
+    # a PR explicitly labelled `pr-pull`.
+    if: >-
+      (github.event_name == 'workflow_run' &&
+       github.event.workflow_run.event == 'pull_request' &&
+       github.event.workflow_run.conclusion == 'success' &&
+       startsWith(github.event.workflow_run.head_branch, 'bump-')) ||
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'pull_request_target' &&
+       contains(github.event.pull_request.labels.*.name, 'pr-pull'))
     runs-on: ubuntu-24.04
     permissions:
       contents: write
@@ -20,12 +52,41 @@ jobs:
       - name: Set up git
         uses: Homebrew/actions/git-user-config@main
 
+      - name: Determine PR number
+        id: pr
+        env:
+          GH_TOKEN: ${{ github.token }}
+          EVENT_NAME: ${{ github.event_name }}
+          DISPATCH_PR: ${{ github.event.inputs.pull_request }}
+          PR_TARGET_NUMBER: ${{ github.event.pull_request.number }}
+          # Populated for same-repo PRs; fall back to a branch lookup if not.
+          RUN_PR_NUMBER: ${{ github.event.workflow_run.pull_requests[0].number }}
+          RUN_HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
+        run: |
+          set -euo pipefail
+          case "$EVENT_NAME" in
+            workflow_dispatch) number="$DISPATCH_PR" ;;
+            pull_request_target) number="$PR_TARGET_NUMBER" ;;
+            workflow_run)
+              number="$RUN_PR_NUMBER"
+              if [ -z "$number" ] || [ "$number" = "null" ]; then
+                number="$(gh pr list --repo "$GITHUB_REPOSITORY" \
+                  --head "$RUN_HEAD_BRANCH" --state all --json number --jq '.[0].number // empty')"
+              fi
+              ;;
+          esac
+          if [ -z "${number:-}" ]; then
+            echo "Could not determine a PR number; nothing to do." >&2
+            exit 1
+          fi
+          echo "number=$number" >> "$GITHUB_OUTPUT"
+
       - name: Pull bottles
         env:
           HOMEBREW_GITHUB_API_TOKEN: ${{ github.token }}
           HOMEBREW_GITHUB_PACKAGES_TOKEN: ${{ github.token }}
           HOMEBREW_GITHUB_PACKAGES_USER: ${{ github.repository_owner }}
-          PULL_REQUEST: ${{ github.event.pull_request.number }}
+          PULL_REQUEST: ${{ steps.pr.outputs.number }}
         run: brew pr-pull --debug --tap="$GITHUB_REPOSITORY" "$PULL_REQUEST"
 
       - name: Push commits
@@ -35,7 +96,7 @@ jobs:
           branch: master
 
       - name: Delete branch
-        if: github.event.pull_request.head.repo.fork == false
+        if: github.event_name != 'workflow_dispatch'
         env:
-          BRANCH: ${{ github.event.pull_request.head.ref }}
-        run: git push --delete origin "$BRANCH"
+          BRANCH: ${{ github.event.workflow_run.head_branch || github.event.pull_request.head.ref }}
+        run: git push --delete origin "$BRANCH" || true

--- a/DEVELOP.md
+++ b/DEVELOP.md
@@ -42,10 +42,27 @@ The new SHA-256 checksum is now in your clipboard. Next:
 - Update the `url` and `sha256` fields in the formula.
 - Commit the changes, push the branch, and open a new PR.
 - Wait for CI to pass – or, at least, yield errors that you can fix or ignore.
-- Merge the PR **by setting the _pr-pull_ label**.
-  - This ^^^^ bit is important, because it triggers the release workflow which
-    inserts/updates the `bottle` stanzas in the formulas.
-
-Your branch will be deleted.
+- Merging and bottle publishing are automatic for version bumps:
+  - **Automated bumps** opened by the `livecheck` workflow use a `bump-*`
+    branch. Once CI passes, the release workflow pulls the freshly-built bottles,
+    inserts/updates the `bottle` stanzas, pushes to `master`, closes the PR, and
+    deletes the branch. There is nothing to remember and no label to set.
+  - **Manual bumps**: name your branch `bump-<formula>-<version>` to get the same
+    automatic handling, or apply the _pr-pull_ label to the PR to trigger the
+    release workflow before merging.
 
 That's all; that should be it.
+
+### Recovery: if bottles didn't get published
+
+If a PR was merged without the release workflow running – e.g. it was merged with
+the button on a branch not named `bump-*` – the bottles may have been built but
+never pushed to ghcr, and `brew install` will then 404 on the missing bottle. To
+recover:
+
+1. Go to **Actions → brew pr-pull → Run workflow**.
+2. Enter the PR number and click **Run workflow**.
+
+This re-runs `brew pr-pull` for that PR, pulling the already-built bottle
+artifacts (CI keeps them for 90 days) and pushing the updated formula to
+`master`.


### PR DESCRIPTION
Fixes the recurring "merged a bump PR, bottles never published, `brew install` 404s" problem (most recently rust-petname 3.0.1).

## Root cause
`publish.yml` only ran on the `pr-pull` **label**. Merging a bump PR with the button skipped it, so test-bot built bottles but nothing pushed them to ghcr, and the formula advertised a bottle that didn't exist.

## Change
- **Automatic publish via `workflow_run`**: when *brew test-bot* finishes successfully on an autobump PR (branch `bump-*`), `brew pr-pull` runs against the still-open PR — its designed mode: pull bottles → ghcr, update the `bottle` stanza, push to master, delete branch. Zero-touch, no label.
- **`workflow_dispatch` fallback**: run *brew pr-pull* for a given PR number to recover a bump whose bottles were built but never pulled.
- **`pr-pull` label preserved** as a manual pre-merge path.
- Event data passed via `env:` (no shell interpolation of branch names).
- DEVELOP.md updated (the old instructions said the label was required).

## Why not the label-auto-apply / on-merge approaches
- Auto-applying the label with `GITHUB_TOKEN` doesn't trigger the `labeled` workflow (GitHub blocks token-triggered runs); a PAT would, but it expires → future silent breakage.
- Triggering on merge (cf. #9) runs `brew pr-pull` against an *already-merged* PR every time, which is the unsupported path. `workflow_run` runs it pre-merge, as designed.

Supersedes #9 (its DEVELOP.md docs + workflow_dispatch recovery are incorporated here).