### PR TITLE
rust-petname: re-pour 3.0.1 bottles

### DIFF
--- a/Formula/rust-petname.rb
+++ b/Formula/rust-petname.rb
@@ -12,11 +12,6 @@ class RustPetname < Formula
     regex(/^v(\d+(?:\.\d+)+)$/i)
   end
 
-  bottle do
-    root_url "https://ghcr.io/v2/allenap/utils"
-    sha256 cellar: :any_skip_relocation, arm64_tahoe:  "7fed414ba5309177b61eea996b1ffbf5b484aa100f724ba2d24a24c946809363"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "98baa12f59094cba836ecb8cf8548ea2b3f1a269adb8d339d550604ab6f5c4be"
-  end
   depends_on "rust" => :build
 
   def install


### PR DESCRIPTION
Recovers the 3.0.1 bottles that were never published (the 3.0.1 bump kept the stale 3.0.0 `bottle` block, so `brew install` 404s on a 3.0.1 bottle that doesn't exist on ghcr).

Dispatching `pr-pull` against the already-merged #10 fails with an empty cherry-pick (its commit is already on master), so this opens a fresh `bump-*` PR with a real diff — removing the stale block — that `pr-pull` can cherry-pick.

Expected flow (hands-off, via the new automation from #11):
1. test-bot builds fresh 3.0.1 bottles on this PR.
2. `workflow_run` fires (`bump-*` + success) → `pr-pull` uploads bottles to ghcr, re-adds the correct 3.0.1 `bottle` stanzas, pushes to master, and merges.

Also serves as the first live exercise of the #11 automation. **Do not merge with the button** — let the workflow handle it (or it'll be the same empty-cherry-pick trap).