### PR TITLE
rust-petname: build with --all-features

### DIFF
--- a/Formula/rust-petname.rb
+++ b/Formula/rust-petname.rb
@@ -4,6 +4,7 @@ class RustPetname < Formula
   url "https://github.com/allenap/rust-petname/archive/refs/tags/v3.0.1.tar.gz"
   sha256 "57dbb72d3e70ef275eea1a477a9f2170835d0f4f22afb6160ae4ec5cf42ad759"
   license "Apache-2.0"
+  revision 1
 
   head "https://github.com/allenap/rust-petname.git", branch: "master"
 
@@ -12,17 +13,10 @@ class RustPetname < Formula
     regex(/^v(\d+(?:\.\d+)+)$/i)
   end
 
-  bottle do
-    root_url "https://ghcr.io/v2/allenap/utils"
-    rebuild 1
-    sha256 cellar: :any_skip_relocation, arm64_tahoe:  "ef30489fef6adabf48c4fc2eb56fb259c8419078f07e2ad977e246cbbfca93ca"
-    sha256 cellar: :any,                 x86_64_linux: "637f7d79647ae5d918e9510bce9d0891506c2d7da5272973ee934c277bf8e20c"
-  end
-
   depends_on "rust" => :build
 
   def install
-    system "cargo", "install", *std_cargo_args
+    system "cargo", "install", *std_cargo_args, "--all-features"
   end
 
   test do
@@ -31,5 +25,7 @@ class RustPetname < Formula
       "--separator", "/",
       "--lists", "large",
       "--count", "10"
+    # The --all-features build includes the Turkish generator.
+    system "#{bin}/petname", "--language", "turkish", "--words", "2"
   end
 end


### PR DESCRIPTION
Builds the bottle with `--all-features` so the Homebrew binary includes the Turkish generator (`--language turkish`) and any other gated features — `cargo`'s features are package-wide, so the only way to ship a full-featured binary is to build it with the features enabled.

- `def install` now passes `--all-features`.
- `revision 1` so already-installed users pick up the rebuilt binary.
- Added a `--language turkish` smoke test to `test do` so the bottle build fails if the feature isn't compiled in.
- Dropped the stale bottle block; `pr-pull` regenerates it from the freshly built bottles.

Hands-off via the #11 automation (branch is `bump-*`): test-bot builds the all-features bottles → `workflow_run` → `pr-pull` publishes + merges. **Don't merge with the button.**